### PR TITLE
Add navigation between screens

### DIFF
--- a/src/feature-dashboard.css
+++ b/src/feature-dashboard.css
@@ -193,7 +193,6 @@ body {
     color: red;
 }
 
-
 .TokenInput.unauthenticated {
     color: lightgrey;
 }
@@ -201,4 +200,23 @@ body {
 .TokenInput.authenticated {
     color: green;
     opacity: 0.3;
+}
+
+nav {
+    margin: 12px;
+    box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2),
+                0px 2px 4px rgba(0, 0, 0, 0.3);
+    padding: 8px 16px;
+    border-radius: 2px;
+    background: white;
+    width: min-content;
+    font-size: 12px;
+}
+
+nav a {
+    padding-right: 5px;
+}
+
+nav a:last-child {
+    padding-right: 0;
 }


### PR DESCRIPTION
This adds a very basic navigation pane below the active pane's content with
links to all possible screens. The links preserve all query args.

![image](https://user-images.githubusercontent.com/279572/59783845-027f1a00-92b9-11e9-9c85-d22a2f062bc0.png)

Fixes https://github.com/vector-im/feature-dashboard/issues/10