### PR TITLE
Support phases on burndown view

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -125,7 +125,7 @@ class App extends Component {
                         <Route exact path="/" component= { RedirectLegacy } />
                         <Route component={ Fail } />
                     </Switch>
-                    <nav>
+                    <nav className="raised-box">
                         {this.routes.map(({ path, label }) => (
                             <Link key={path} to={this.pathWithQuery(path)}>
                                 {label}

--- a/src/components/Burndown.js
+++ b/src/components/Burndown.js
@@ -82,25 +82,15 @@ class Burndown extends Component {
         let sort = (a, b) => {
             return Number(a.split(":")[1]) - Number(b.split(":")[1]);
         };
-        // TODO: Do we wanted unbucketed for this view?
-        // let unbucketed = 'unphased';
-        let unbucketed;
 
         let headings = [...new Set(issues.filter(label).map(label))].sort(sort);
         let buckets = {};
-        headings.forEach(heading => {
-            buckets[heading] = issues.filter(item => label(item) === heading);
-        });
-
-        // If we're interested in issues that weren't matched by the filter,
-        // throw them into an 'unbucketed' category.
-        if (unbucketed) {
-            let unbucketedItems = issues.filter(item =>
-                !Object.values(buckets).reduce(Array.concat, []).includes(item));
-
-            if (unbucketedItems.length > 0) {
-                buckets[unbucketed] = unbucketedItems;
-            }
+        if (headings.length > 0) {
+            headings.forEach(heading => {
+                buckets[heading] = issues.filter(item => label(item) === heading);
+            });
+        } else {
+            buckets['unphased'] = issues;
         }
 
         let datasets = [];

--- a/src/components/Burndown.js
+++ b/src/components/Burndown.js
@@ -24,7 +24,7 @@ class Burndown extends Component {
     render() {
         if (this.props.issues.length === 0) {
             return (
-                <div className="Burndown">
+                <div className="Burndown raised-box">
                     <h3>Loading data...</h3>
                 </div>
             );
@@ -123,7 +123,7 @@ class Burndown extends Component {
         };
 
         return (
-            <div className="Burndown">
+            <div className="Burndown raised-box">
                 <h3>{ this.props.labels.join(' ') }</h3>
                 <Line data={ data } options={ options }/>
             </div>

--- a/src/components/Burndown.js
+++ b/src/components/Burndown.js
@@ -55,13 +55,20 @@ class Burndown extends Component {
         let closedIssueDeltas = {};
 
         // Initialise dates array and issue count per day for all relevant dates
-        let date = new Date(
-            Math.min(
-                ...issues.map(issue => new Date(issue.githubIssue.created_at))
-            )
-        );
+        // Start at from creation time of the earliest issue by default
+        // Limit to one year at most
+        // TODO: URL param for custom start date?
         let today = new Date();
         let tomorrow = new Date().setDate(today.getDate() + 1);
+        let oneYearAgo = new Date().setFullYear(today.getFullYear() - 1);
+        let date = new Date(
+            Math.max(
+                Math.min(
+                    ...issues.map(issue => new Date(issue.githubIssue.created_at))
+                ),
+                oneYearAgo
+            )
+        );
         while (date < tomorrow) {
             let day = dateFormat(date, 'yyyy-mm-dd');
             dates.push(day);
@@ -103,7 +110,7 @@ class Burndown extends Component {
             });
 
             buckets[bucket].forEach(issue => {
-                let start = dates.indexOf(dateFormat(issue.githubIssue.created_at, 'yyyy-mm-dd'));
+                let start = Math.max(0, dates.indexOf(dateFormat(issue.githubIssue.created_at, 'yyyy-mm-dd')));
                 let end = issue.githubIssue.closed_at ? dates.indexOf(dateFormat(issue.githubIssue.closed_at, 'yyyy-mm-dd')) : dates.length;
                 for (let n = start; n < end; n++) {
                     openIssueCounts[dates[n]][bucket] += 1;

--- a/src/components/Burndown.js
+++ b/src/components/Burndown.js
@@ -146,6 +146,7 @@ class Burndown extends Component {
         let todaysDate = dates[dates.length - 1];
         let elapsedDays = dates.length;
         let previousBucketRemainingDays = 0;
+        let previousBucketFractionalDays = 0;
         Object.keys(buckets).forEach((bucket, index) => {
             let todaysIssues = openIssueCounts[todaysDate][bucket];
             let remainingDays = todaysIssues / closeRate;
@@ -169,10 +170,13 @@ class Burndown extends Component {
                 for (let i = 0; i < previousBucketRemainingDays; i++) {
                     projection.push(todaysIssues);
                 }
-                for (let i = 0; i < remainingDays; i++) {
+                for (let i = previousBucketFractionalDays; i < remainingDays + 1; i++) {
                     projection.push(todaysIssues - (i * closeRate));
                 }
-                projection.push(0);
+                // Store fractional days to the next date to help the next
+                // bucket stack smoothly.
+                previousBucketFractionalDays = Math.ceil(remainingDays) - remainingDays;
+
                 datasets.push({
                     label: `Projected ${bucket} delivery`,
                     data: projection,

--- a/src/components/Burndown.js
+++ b/src/components/Burndown.js
@@ -19,6 +19,24 @@ import React, { Component } from 'react';
 import dateFormat from 'dateformat';
 import { Line } from 'react-chartjs-2';
 
+const FILL_COLORS = [
+    'rgba(0, 40, 0, 0.2)',
+    'rgba(40, 0, 0, 0.2)',
+    'rgba(0, 0, 40, 0.2)',
+    'rgba(40, 40, 0, 0.2)',
+    'rgba(0, 40, 40, 0.2)',
+    'rgba(40, 0, 40, 0.2)',
+];
+
+const LINE_COLORS = [
+    'rgba(0, 40, 0, 0.5)',
+    'rgba(40, 0, 0, 0.5)',
+    'rgba(0, 0, 40, 0.5)',
+    'rgba(40, 40, 0, 0.5)',
+    'rgba(0, 40, 40, 0.5)',
+    'rgba(40, 0, 40, 0.5)',
+];
+
 class Burndown extends Component {
 
     render() {
@@ -88,7 +106,7 @@ class Burndown extends Component {
         let datasets = [];
 
         // Create a dataset for each bucket
-        Object.keys(buckets).forEach(bucket => {
+        Object.keys(buckets).forEach((bucket, index) => {
             // Initialise counts to 0 for this bucket for all dates
             Object.keys(openIssueCounts).forEach(date => {
                 openIssueCounts[date][bucket] = 0;
@@ -105,6 +123,7 @@ class Burndown extends Component {
                 label: `Open ${bucket} issues`,
                 data: dates.map(date => openIssueCounts[date][bucket]),
                 lineTension: 0,
+                backgroundColor: FILL_COLORS[index],
             });
         });
 
@@ -128,7 +147,7 @@ class Burndown extends Component {
 
         // Attempt to project a delivery date for each bucket
         let todaysDate = dates[dates.length - 1];
-        Object.keys(buckets).forEach(bucket => {
+        Object.keys(buckets).forEach((bucket, index) => {
             let todaysIssues = openIssueCounts[todaysDate][bucket];
             let elapsedDays = dates.length;
             let remainingDays = todaysIssues / closeRate;
@@ -153,10 +172,10 @@ class Burndown extends Component {
                     label: `Projected ${bucket} delivery`,
                     data: projection,
                     lineTension: 0,
-                    fill: false,
                     pointRadius: 0,
-                    borderColor: '#738d04',
-                    borderWidth: 1,
+                    borderColor: LINE_COLORS[index],
+                    borderWidth: 2,
+                    backgroundColor: FILL_COLORS[index],
                 });
             }
         });

--- a/src/components/Burndown.js
+++ b/src/components/Burndown.js
@@ -22,7 +22,9 @@ import { Line } from 'react-chartjs-2';
 class Burndown extends Component {
 
     render() {
-        if (this.props.issues.length === 0) {
+        let { issues } = this.props;
+
+        if (issues.length === 0) {
             return (
                 <div className="Burndown raised-box">
                     <h3>Loading data...</h3>
@@ -33,11 +35,10 @@ class Burndown extends Component {
         let dates = [];
         let issueCounts = {};
 
+        // Initialise dates array and issue count per day for all relevant dates
         let date = new Date(
             Math.min(
-                ...this.props.issues.map(
-                    issue => new Date(issue.githubIssue.created_at)
-                )
+                ...issues.map(issue => new Date(issue.githubIssue.created_at))
             )
         );
         let today = new Date();
@@ -45,68 +46,112 @@ class Burndown extends Component {
         while (date < tomorrow) {
             let day = dateFormat(date, 'yyyy-mm-dd');
             dates.push(day);
-            issueCounts[day] = 0;
+            issueCounts[day] = {};
             date.setDate(date.getDate() + 1);
         }
 
-        this.props.issues.forEach(issue => {
-            let start = dates.indexOf(dateFormat(issue.githubIssue.created_at, 'yyyy-mm-dd'));
-            let end = issue.githubIssue.closed_at ? dates.indexOf(dateFormat(issue.githubIssue.closed_at, 'yyyy-mm-dd')) : dates.length;
-            for (let n = start; n < end; n++) {
-                issueCounts[dates[n]] += 1;
+        // Attempt to bucket issues by phase
+        // TODO: Extract this out as a generic issue categoriser
+        let label = issue => {
+            let phases = issue.labels.filter(label => label.name.startsWith('phase:'));
+            if (phases.length > 0) {
+                return phases[0].name;
             }
+            return null;
+        };
+        let sort = (a, b) => {
+            return Number(a.split(":")[1]) - Number(b.split(":")[1]);
+        };
+        // TODO: Do we wanted unbucketed for this view?
+        // let unbucketed = 'unphased';
+        let unbucketed;
+
+        let headings = [...new Set(issues.filter(label).map(label))].sort(sort);
+        let buckets = {};
+        headings.forEach(heading => {
+            buckets[heading] = issues.filter(item => label(item) === heading);
         });
 
-        let datasets = [
-            {
-                label: 'Open issues',
-                data: dates.map(date => issueCounts[date]),
-                lineTension: 0,
-            }
-        ];
+        // If we're interested in issues that weren't matched by the filter,
+        // throw them into an 'unbucketed' category.
+        if (unbucketed) {
+            let unbucketedItems = issues.filter(item =>
+                !Object.values(buckets).reduce(Array.concat, []).includes(item));
 
-        let maxDate = Object.keys(issueCounts)
-            .reduce((a, b) => {
-                if (issueCounts[a] === issueCounts[b]) {
-                    return a < b ? a : b;
-                }
-                else {
-                    return issueCounts[a] > issueCounts[b] ? a : b
-                }
-            });
-
-        let maxIssues = issueCounts[maxDate];
-        let todaysIssues = issueCounts[dates[dates.length - 1]];
-        let elapsedDays = (dates.length - dates.indexOf(maxDate) - 1);
-        let rate = (maxIssues - todaysIssues) / elapsedDays;
-        let totalDays = dates.indexOf(maxDate) + 1 + (maxIssues / rate);
-        let remainingDays = totalDays - dates.length;
-
-        if (remainingDays !== Infinity) {
-            let date = new Date(dates[dates.length - 1]);
-            for (let i = 0; i < remainingDays + 1; i++) {
-                date.setDate(date.getDate() + 1);
-                dates.push(dateFormat(date, 'yyyy-mm-dd'));
+            if (unbucketedItems.length > 0) {
+                buckets[unbucketed] = unbucketedItems;
             }
-            let projection = [];
-            for (let i = 0; i < dates.indexOf(maxDate); i++) {
-                projection.push(null);
-            }
-            for (let i = 0; i < elapsedDays + remainingDays; i++) {
-                projection.push(maxIssues - (i * rate));
-            }
-            projection.push(0);
-            datasets.push({
-                label: 'Projected delivery',
-                data: projection,
-                lineTension: 0,
-                fill: false,
-                pointRadius: 0,
-                borderColor: '#738d04',
-                borderWidth: 1
-            });
-
         }
+
+        let datasets = [];
+
+        // Create a dataset for each bucket
+        Object.keys(buckets).forEach(bucket => {
+            // Initialise counts to 0 for this bucket for all dates
+            Object.keys(issueCounts).forEach(date => {
+                issueCounts[date][bucket] = 0;
+            });
+
+            buckets[bucket].forEach(issue => {
+                let start = dates.indexOf(dateFormat(issue.githubIssue.created_at, 'yyyy-mm-dd'));
+                let end = issue.githubIssue.closed_at ? dates.indexOf(dateFormat(issue.githubIssue.closed_at, 'yyyy-mm-dd')) : dates.length;
+                for (let n = start; n < end; n++) {
+                    issueCounts[dates[n]][bucket] += 1;
+                }
+            });
+            datasets.push({
+                label: `Open ${bucket} issues`,
+                data: dates.map(date => issueCounts[date][bucket]),
+                lineTension: 0,
+            });
+        });
+
+        let todaysDate = dates[dates.length - 1];
+
+        // Attempt to project a delivery date for each bucket
+        Object.keys(buckets).forEach(bucket => {
+            let maxDate = Object.keys(issueCounts)
+                .reduce((a, b) => {
+                    if (issueCounts[a][bucket] === issueCounts[b][bucket]) {
+                        return a < b ? a : b;
+                    }
+                    return issueCounts[a][bucket] > issueCounts[b][bucket] ? a : b;
+                });
+            let maxIssues = issueCounts[maxDate][bucket];
+            let todaysIssues = issueCounts[todaysDate][bucket];
+            let fromMaxToTodayDays = (dates.length - dates.indexOf(maxDate) - 1);
+            // TODO: Use a better estimate of team velocity
+            let rate = (maxIssues - todaysIssues) / fromMaxToTodayDays;
+            let totalDays = dates.indexOf(maxDate) + 1 + (maxIssues / rate);
+            let remainingDays = totalDays - dates.length;
+
+            if (todaysIssues > 0 && remainingDays !== Infinity) {
+                let date = new Date(todaysDate);
+                for (let i = 0; i < remainingDays + 1; i++) {
+                    let day = dateFormat(date, 'yyyy-mm-dd');
+                    dates.push(day);
+                    issueCounts[day] = {};
+                    date.setDate(date.getDate() + 1);
+                }
+                let projection = [];
+                for (let i = 0; i < dates.indexOf(maxDate) + fromMaxToTodayDays + 1; i++) {
+                    projection.push(null);
+                }
+                for (let i = fromMaxToTodayDays; i < totalDays; i++) {
+                    projection.push(maxIssues - (i * rate));
+                }
+                projection.push(0);
+                datasets.push({
+                    label: `Projected ${bucket} delivery`,
+                    data: projection,
+                    lineTension: 0,
+                    fill: false,
+                    pointRadius: 0,
+                    borderColor: '#738d04',
+                    borderWidth: 1,
+                });
+            }
+        });
 
         let data = {
             labels: dates,
@@ -115,6 +160,7 @@ class Burndown extends Component {
         let options = {
             scales: {
                 yAxes: [{
+                    stacked: true,
                     ticks: {
                         min: 0
                     }

--- a/src/components/Plan.js
+++ b/src/components/Plan.js
@@ -121,7 +121,7 @@ class Plan extends Component {
         };
 
         return (
-            <div className="Plan">
+            <div className="Plan raised-box">
                 <p className="label">{ this.props.labels.join(' ') }</p>
                 <IssueTree
                     categories={ categories }

--- a/src/components/Summary.js
+++ b/src/components/Summary.js
@@ -314,7 +314,7 @@ class Summary extends Component {
         );
 
         return (
-            <div className="Summary">
+            <div className="Summary raised-box">
                 <div className="Summary-Header">
                     <div className="Label">{ feature.labels.join(' ') }</div>
                     <div className="PercentComplete">{ this.calculatePercentCompleted(feature) }%</div>

--- a/src/feature-dashboard.css
+++ b/src/feature-dashboard.css
@@ -22,31 +22,24 @@ body {
     background: #f8f9fa;
 }
 
-.Burndown {
+.raised-box {
     margin: 12px;
-    display: inline-block;
+    padding: 8px 16px;
+    background: white;
+    border-radius: 2px;
     box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2),
                 0px 2px 4px rgba(0, 0, 0, 0.3);
-    padding: 16px;
-    padding-right: 34px;
-    padding-bottom: 8px;
-    border-radius: 2px;
-    background: white;
+}
+
+.Burndown {
+    display: inline-block;
     width: 90%;
 }
 
 .Plan {
     font-family: Arial;
     font-size: 15px;
-    margin: 12px;
     display: inline-block;
-    box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2),
-                0px 2px 4px rgba(0, 0, 0, 0.3);
-    padding: 16px;
-    padding-right: 34px;
-    padding-bottom: 8px;
-    border-radius: 2px;
-    background: white;
 }
 
 .Plan .state {
@@ -74,14 +67,7 @@ body {
 }
 
 .Summary {
-    margin: 12px;
     display: inline-block;
-    box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2),
-                0px 2px 4px rgba(0, 0, 0, 0.3);
-    padding: 16px;
-    padding-bottom: 8px;
-    border-radius: 2px;
-    background: white;
 }
 
 .Summary-Header {
@@ -219,12 +205,6 @@ body {
 }
 
 nav {
-    margin: 12px;
-    box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2),
-                0px 2px 4px rgba(0, 0, 0, 0.3);
-    padding: 8px 16px;
-    border-radius: 2px;
-    background: white;
     width: min-content;
     font-size: 12px;
 }


### PR DESCRIPTION
**Reviewer:** This is a large change, so you may want to review commit by commit.

This adds support for phases to the burndown view. Each phase's open issues have a separate line in a stacked chart. A projected delivery date is also determined for each active phase.

This also tweaks the burndown rate estimation to use the last 2 weeks of issues closed in the project, rather than the slope from the max issue point, which should hopefully be more accurate.

![image](https://user-images.githubusercontent.com/279572/60467365-5e995500-9c4e-11e9-9b39-c2718cec63b7.png)

Fixes https://github.com/vector-im/feature-dashboard/issues/12