### PR TITLE
Preserve repo ordering on plan view

### DIFF
--- a/src/components/Plan.js
+++ b/src/components/Plan.js
@@ -99,6 +99,12 @@ class Plan extends Component {
         if (this.props.repos.length > 1) {
             categories.push({
                 label: issue => issue.owner + '/' + issue.repo,
+                sort: (a, b) => {
+                    // Preserve repo ordering as entered by user
+                    const ai = this.props.repos.indexOf(a);
+                    const bi = this.props.repos.indexOf(b);
+                    return ai - bi;
+                },
             });
         }
         let renderLabel = (issue, label) => {


### PR DESCRIPTION
This uses the same repo ordering on the plan view as the list of repos in the
address bar, which allows manually tweaking the order when desired.