### PR TITLE
Limit Burndown view to at most 3 months

### DIFF
--- a/src/components/Burndown.js
+++ b/src/components/Burndown.js
@@ -79,11 +79,11 @@ class Burndown extends Component {
 
         // Initialise dates array and issue count per day for all relevant dates
         // Start at from creation time of the earliest issue by default
-        // Limit to one year at most
+        // Limit to three months at most
         // TODO: URL param for custom start date?
         let today = new Date();
         let tomorrow = new Date().setDate(today.getDate() + 1);
-        let oneYearAgo = new Date().setFullYear(today.getFullYear() - 1);
+        let threeMonthsAgo = new Date().setMonth(today.getMonth() - 3);
         let displayedIssues = Object.values(buckets).reduce((array, value) => {
             return array.concat(value);
         });
@@ -92,7 +92,7 @@ class Burndown extends Component {
                 Math.min(
                     ...displayedIssues.map(issue => new Date(issue.githubIssue.created_at))
                 ),
-                oneYearAgo
+                threeMonthsAgo
             )
         );
         while (date < tomorrow) {


### PR DESCRIPTION
The previous 1 year limit is too much to make sense of at one time. Hopefully 3
months will be a better default.

![image](https://user-images.githubusercontent.com/279572/63297947-68444e00-c2ca-11e9-8545-9a04394e4645.png)
