### PR TITLE
Split others in Summary by status

### DIFF
--- a/src/components/Summary.js
+++ b/src/components/Summary.js
@@ -268,8 +268,38 @@ class SummaryRow extends Component {
                     this.makeLink(
                         repoFeature.repo,
                         repoFeature.labels,
-                        ['is:open'].concat(repoFeature.todo.others.concat(repoFeature.wip.others).map(issue => issue.number)),
-                        repoFeature.todo.others.concat(repoFeature.wip.others)
+                        [
+                            'is:open',
+                            'no:assignee',
+                            '-label:feature',
+                            '-label:bug',
+                        ],
+                        repoFeature.todo.others
+                    )
+                }</div>
+                <div>{
+                    this.makeLink(
+                        repoFeature.repo,
+                        repoFeature.labels,
+                        [
+                            'is:open',
+                            'assignee:*',
+                            '-label:feature',
+                            '-label:bug',
+                        ],
+                        repoFeature.wip.others
+                    )
+                }</div>
+                <div>{
+                    this.makeLink(
+                        repoFeature.repo,
+                        repoFeature.labels,
+                        [
+                            'is:closed',
+                            '-label:feature',
+                            '-label:bug',
+                        ],
+                        repoFeature.done.others
                     )
                 }</div>
                 <div className={ repoFeature.deliveryDate ? "" : "NoDate" }>{ repoFeature.deliveryDate ?
@@ -329,7 +359,9 @@ class Summary extends Component {
                     <div className="Summary-Column Bugs"></div>
                     <div className="Summary-Column Bugs"></div>
                     <div className="Summary-Column Bugs"></div>
-                    <div className="Summary-Column"></div>
+                    <div className="Summary-Column Implementation"></div>
+                    <div className="Summary-Column Implementation"></div>
+                    <div className="Summary-Column Implementation"></div>
                     <div className="Summary-Column"></div>
                     <div className="Summary-Column"></div>
                     <div className="Summary-Row Summary-TableHeader">
@@ -342,7 +374,9 @@ class Summary extends Component {
                         <div>P3</div>
                         <div>WIP</div>
                         <div>Fixed</div>
-                        <div>Other</div>
+                        <div><span className="MetaTitleHolder"><span className="MetaTitle">Other</span></span>Todo</div>
+                        <div>WIP</div>
+                        <div>Done</div>
                         <div>Delivery</div>
                         <div></div>
                     </div>

--- a/src/feature-dashboard.css
+++ b/src/feature-dashboard.css
@@ -154,11 +154,11 @@ body {
     padding-right: 30px;
 }
 
-.Summary-Row div:nth-child(10) {
+.Summary-Row div:nth-child(12) {
     padding-right: 20px;
 }
 
-.Summary-Row div:nth-child(11) {
+.Summary-Row div:nth-child(13) {
     padding-right: 20px;
 }
 


### PR DESCRIPTION
The "others" group in the Summary was only showing things not done (either todo or wip), causing confusion as it diverges from number on the Plan.

A separate problem remains (https://github.com/vector-im/feature-dashboard/issues/48) that we don't include the other group in the percent complete, which may also be confusing.

![image](https://user-images.githubusercontent.com/279572/64176248-eb31e080-ce54-11e9-91a6-9040872acd4d.png)

Fixes https://github.com/vector-im/feature-dashboard/issues/47